### PR TITLE
Improve remote connection reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
+ "once_cell",
  "parking_lot",
  "rand 0.9.0",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ swash = { version = "0.2.1", default-features = false, features = [ "std"  ] }
 time = { version = "0.3.37", features = ["macros", "formatting"] }
 tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["compat"] }
+once_cell = "1.19.0"
 toml = "0.8.19"
 tracy-client-sys = { version = "0.24.3", optional = true, default-features = false, features = [
     "broadcast",

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -170,7 +170,7 @@ async fn run(session: NeovimSession, proxy: EventLoopProxy<UserEvent>) {
     proxy.send_event(UserEvent::NeovimExited).ok();
 }
 
-async fn run_server(mut session: NeovimSession, proxy: EventLoopProxy<UserEvent>) {
+async fn run_server(mut session: NeovimSession) {
     debug!("Monitoring server connection");
     let mut ping_interval = interval(Duration::from_secs(5));
     loop {
@@ -191,7 +191,7 @@ async fn run_server(mut session: NeovimSession, proxy: EventLoopProxy<UserEvent>
     if let Some(stderr_task) = &mut session.stderr_task {
         timeout(Duration::from_millis(500), stderr_task).await.ok();
     }
-    proxy.send_event(UserEvent::NeovimExited).ok();
+    debug!("Server session ended");
 }
 
 async fn run_with_reconnect(
@@ -209,7 +209,7 @@ async fn run_with_reconnect(
             Ok(session) => {
                 info!("Connected to {address}");
                 proxy.send_event(UserEvent::ReconnectStop).ok();
-                run_server(session, proxy.clone()).await;
+                run_server(session).await;
                 warn!("Connection to {address} lost");
                 wait = Duration::from_secs(1);
             }

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -74,7 +74,10 @@ impl NeovimSession {
         )
         .await
         .map_err(|_| Error::new(ErrorKind::TimedOut, "Handshake timeout"))?;
-        log::debug!("Handshake result: {:?}", handshake_res.as_ref().map(|_| "ok"));
+        log::debug!(
+            "Handshake result: {:?}",
+            handshake_res.as_ref().map(|_| "ok")
+        );
         match handshake_res {
             Err(err) => {
                 log::error!("Handshake failed: {err}");
@@ -169,7 +172,11 @@ impl NeovimInstance {
         } else {
             #[cfg(unix)]
             {
-                let stream = timeout(Duration::from_secs(5), tokio::net::UnixStream::connect(&address)).await??;
+                let stream = timeout(
+                    Duration::from_secs(5),
+                    tokio::net::UnixStream::connect(&address),
+                )
+                .await??;
                 log::debug!("Unix socket connect succeeded");
                 return Ok(Self::split(stream));
             }

--- a/src/renderer/reconnect_indicator.rs
+++ b/src/renderer/reconnect_indicator.rs
@@ -62,7 +62,7 @@ impl ReconnectIndicator {
             return;
         }
         let remaining = self.end_time.saturating_duration_since(Instant::now());
-        let secs = remaining.as_secs();
+        let secs = remaining.as_secs_f32().ceil() as u64;
         let text = format!("Reconnecting to {} in {}s", self.address, secs);
 
         canvas.save();

--- a/src/renderer/reconnect_indicator.rs
+++ b/src/renderer/reconnect_indicator.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use skia_safe::{Canvas, Color, Paint, Point};
+
+use crate::profiling::tracy_zone;
+use crate::renderer::fonts::font_loader::{FontKey, FontLoader, FontPair};
+use crate::settings::Settings;
+
+pub struct ReconnectIndicator {
+    font: Arc<FontPair>,
+    active: bool,
+    address: String,
+    end_time: Instant,
+    angle: f32,
+    #[allow(dead_code)]
+    settings: Arc<Settings>,
+}
+
+impl ReconnectIndicator {
+    pub fn new(settings: Arc<Settings>) -> Self {
+        let font_key = FontKey::default();
+        let mut loader = FontLoader::new(16.0);
+        let font = loader.get_or_load(&font_key).expect("Font load failed");
+        Self {
+            font,
+            active: false,
+            address: String::new(),
+            end_time: Instant::now(),
+            angle: 0.0,
+            settings,
+        }
+    }
+
+    pub fn start(&mut self, address: String, wait: Duration) {
+        self.address = address;
+        self.end_time = Instant::now() + wait;
+        self.angle = 0.0;
+        self.active = true;
+    }
+
+    pub fn stop(&mut self) {
+        self.active = false;
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn update(&mut self, dt: f32) {
+        if self.active {
+            self.angle += dt * std::f32::consts::PI * 2.0;
+            if self.angle > std::f32::consts::PI * 2.0 {
+                self.angle -= std::f32::consts::PI * 2.0;
+            }
+        }
+    }
+
+    pub fn draw(&self, canvas: &Canvas) {
+        tracy_zone!("reconnect_indicator_draw");
+        if !self.active {
+            return;
+        }
+        let remaining = self.end_time.saturating_duration_since(Instant::now());
+        let secs = remaining.as_secs();
+        let text = format!("Reconnecting to {} in {}s", self.address, secs);
+
+        canvas.save();
+
+        let mut paint = Paint::default();
+        paint.set_anti_alias(true);
+
+        let spinner_radius = self.font.skia_font.size();
+        let center = (40.0, 40.0);
+
+        paint.set_color(Color::from_argb(255, 80, 80, 80));
+        canvas.draw_circle(center, spinner_radius, &paint);
+
+        paint.set_color(Color::WHITE);
+        let arm_x = center.0 + spinner_radius * self.angle.cos();
+        let arm_y = center.1 + spinner_radius * self.angle.sin();
+        canvas.draw_line(center, (arm_x, arm_y), &paint);
+
+        let text_pos = Point::new(
+            center.0 + spinner_radius + 10.0,
+            center.1 + self.font.skia_font.size() / 2.0,
+        );
+        canvas.draw_str(text, text_pos, &self.font.skia_font, &paint);
+
+        canvas.restore();
+    }
+}

--- a/src/renderer/reconnect_indicator.rs
+++ b/src/renderer/reconnect_indicator.rs
@@ -71,8 +71,14 @@ impl ReconnectIndicator {
         paint.set_anti_alias(true);
 
         let spinner_radius = self.font.skia_font.size();
-        let center = (40.0, 40.0);
+        let size = canvas.base_layer_size();
+        let center = (size.width as f32 / 2.0, size.height as f32 / 2.0);
 
+        // Dim the background while reconnecting
+        paint.set_color(Color::from_argb(160, 0, 0, 0));
+        canvas.draw_paint(&paint);
+
+        // Draw the spinner
         paint.set_color(Color::from_argb(255, 80, 80, 80));
         canvas.draw_circle(center, spinner_radius, &paint);
 
@@ -81,9 +87,10 @@ impl ReconnectIndicator {
         let arm_y = center.1 + spinner_radius * self.angle.sin();
         canvas.draw_line(center, (arm_x, arm_y), &paint);
 
+        let width = self.font.skia_font.measure_str(&text, Some(&paint)).0;
         let text_pos = Point::new(
-            center.0 + spinner_radius + 10.0,
-            center.1 + self.font.skia_font.size() / 2.0,
+            center.0 - width / 2.0,
+            center.1 + spinner_radius + self.font.skia_font.size(),
         );
         canvas.draw_str(text, text_pos, &self.font.skia_font, &paint);
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -95,6 +95,11 @@ pub enum UserEvent {
     #[allow(dead_code)]
     RedrawRequested,
     NeovimExited,
+    ReconnectStart {
+        address: String,
+        wait: u64,
+    },
+    ReconnectStop,
 }
 
 impl From<Vec<DrawCommand>> for UserEvent {

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -374,6 +374,15 @@ impl ApplicationHandler<UserEvent> for UpdateLoop {
                 // They will be processed immediately after the rendering.
                 self.pending_draw_commands.push(batch);
             }
+            UserEvent::ReconnectStart { address, wait } => {
+                self.window_wrapper
+                    .start_reconnect(address, Duration::from_secs(wait));
+                self.should_render = ShouldRender::Immediately;
+            }
+            UserEvent::ReconnectStop => {
+                self.window_wrapper.stop_reconnect();
+                self.should_render = ShouldRender::Immediately;
+            }
             _ => {
                 self.window_wrapper.handle_user_event(event);
                 self.should_render = ShouldRender::Immediately;

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -375,11 +375,13 @@ impl ApplicationHandler<UserEvent> for UpdateLoop {
                 self.pending_draw_commands.push(batch);
             }
             UserEvent::ReconnectStart { address, wait } => {
+                log::debug!("Displaying reconnect spinner: {address} in {}s", wait);
                 self.window_wrapper
                     .start_reconnect(address, Duration::from_secs(wait));
                 self.should_render = ShouldRender::Immediately;
             }
             UserEvent::ReconnectStop => {
+                log::debug!("Hiding reconnect spinner");
                 self.window_wrapper.stop_reconnect();
                 self.should_render = ShouldRender::Immediately;
             }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -197,6 +197,9 @@ impl WinitWindowWrapper {
 
     pub fn start_reconnect(&mut self, address: String, wait: Duration) {
         self.renderer.start_reconnect(address, wait);
+        if self.ui_state == UIState::Initing {
+            self.ui_state = UIState::WaitingForWindowCreate;
+        }
     }
 
     pub fn stop_reconnect(&mut self) {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use log::trace;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -193,6 +193,14 @@ impl WinitWindowWrapper {
         if let Some(skia_renderer) = &self.skia_renderer {
             skia_renderer.window().set_ime_allowed(ime_enabled);
         }
+    }
+
+    pub fn start_reconnect(&mut self, address: String, wait: Duration) {
+        self.renderer.start_reconnect(address, wait);
+    }
+
+    pub fn stop_reconnect(&mut self) {
+        self.renderer.stop_reconnect();
     }
 
     pub fn handle_window_command(&mut self, command: WindowCommand) {
@@ -431,6 +439,12 @@ impl WinitWindowWrapper {
             }
             UserEvent::ConfigsChanged(config) => {
                 self.handle_config_changed(*config);
+            }
+            UserEvent::ReconnectStart { address, wait } => {
+                self.start_reconnect(address, Duration::from_secs(wait));
+            }
+            UserEvent::ReconnectStop => {
+                self.stop_reconnect();
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- add reconnect spinner overlay and events
- retry server connections with exponential backoff
- apply connection and handshake timeouts

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68411c58d66483289a7460dc56a5294b